### PR TITLE
support for img attrs values with 'px' ending

### DIFF
--- a/upyachka.jquery.js
+++ b/upyachka.jquery.js
@@ -55,7 +55,7 @@
     if (ratio && enabled) {
         img.className += ' upyachka';
         fixHeight();
-        return S.utils.upyachka.addEvent(window, 'resize', fixHeight);
+        return addEvent(window, 'resize', fixHeight);
     }
   };
 

--- a/upyachka.jquery.js
+++ b/upyachka.jquery.js
@@ -43,11 +43,19 @@
     };
     var width = img.getAttribute('width');
     var height = img.getAttribute('height');
-    var ratio = width / height;
-    if (enabled) {
-      img.className += ' upyachka';
-      fixHeight();
-      return addEvent(window, 'resize', fixHeight);
+    var ratio;
+    if (width / height) {
+        ratio = width / height;
+    } else {
+        var pxRE = /^[0-9]*\.?[0-9]+px$/i;
+        if (pxRE.test(width) && pxRE.test(height)) {
+            ratio = parseFloat(width) / parseFloat(height);
+        }
+    }
+    if (ratio && enabled) {
+        img.className += ' upyachka';
+        fixHeight();
+        return S.utils.upyachka.addEvent(window, 'resize', fixHeight);
     }
   };
 


### PR DESCRIPTION
If width and height img attributes set with 'px' ending then ratio is NaN and plugin fails. I added check if both width & height are valid values with 'px' ending. Then, in this case, plugin parses floats from these values to find the ratio later.
